### PR TITLE
Fixes the list_dirs function

### DIFF
--- a/client.py
+++ b/client.py
@@ -185,7 +185,7 @@ class Client:
         if not self.space_files or space_name:
             self.refresh_files(space_name)
 
-        files = sort_files(self.space_files, dir, 'directory')
+        files = sort_files(self.space_files, path, 'directory')
 
         if not string:
             return files


### PR DESCRIPTION
Currently `list_dirs` tries to sort using `dir` which isn't a variable in the function so it defaults to the built-in function which throws an error.  Changing this to `path` fixes the bug.